### PR TITLE
Disallow imports

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -125,7 +125,7 @@ function findLintErrors(fileName, fileContent) {
     positions: true
   });
 
-  // console.log(JSON.stringify(ast, null, 2));
+  console.log(JSON.stringify(ast, null, 2));
 
   const indicesOfIgnoredLines = getIndicesOfIgnoredLines(fileContent);
 
@@ -147,6 +147,7 @@ function findLintErrors(fileName, fileContent) {
       maybeAddError(checkIfStartsWithComponentName(fileName, node));
       maybeAddError(checkIfAnimationStartsWithComponentName(fileName, node));
       maybeAddError(checkIfUsesTypeSelector(nodeContext, node, item));
+      maybeAddError(checkIfHasImports(fileName, node));
     }
   });
 
@@ -256,6 +257,18 @@ function checkIfUsesTypeSelector(nodeContext, node) {
   There is a type selector ${colors.red(node.name)}`;
   }
 
+  return "no error";
+}
+
+/*
+    All imports are disallowed except for main.css
+*/
+function checkIfHasImports(fileName, node) {
+  if (fileName !== "main" && node.type === "Atrule" && node.name === "import") {
+    return `  ${colors.underline(`on line ${node.loc.start.line}:`)}
+  There is an import rule.
+  All imports are disallowed except for main.css`;
+  }
   return "no error";
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -125,7 +125,7 @@ function findLintErrors(fileName, fileContent) {
     positions: true
   });
 
-  console.log(JSON.stringify(ast, null, 2));
+  // console.log(JSON.stringify(ast, null, 2));
 
   const indicesOfIgnoredLines = getIndicesOfIgnoredLines(fileContent);
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -248,8 +248,7 @@ function checkIfAnimationStartsWithComponentName(fileName, node) {
 }
 
 /*
-    Type selectors (like "div", "ul", "li", ...) are only allowed
-      if they appear on the right hand side of a child combinator (like "my--form__list > li")
+    Type selectors (like "div", "ul", "li", ...) are not allowed.
 */
 function checkIfUsesTypeSelector(nodeContext, node) {
   if (node.type === "TypeSelector" && nodeContext.atrule === null) {
@@ -261,12 +260,11 @@ function checkIfUsesTypeSelector(nodeContext, node) {
 }
 
 /*
-    All imports are disallowed except for main.css
+    Imports are only allowed in main.css
 */
 function checkIfHasImports(fileName, node) {
   if (fileName !== "main" && node.type === "Atrule" && node.name === "import") {
     return `  ${colors.underline(`on line ${node.loc.start.line}:`)}
-  There is an import rule.
   Imports are only allowed in main.css.
   Having all imports in one file guarantees 
   that there is only one place in the project

--- a/bin/index.js
+++ b/bin/index.js
@@ -267,7 +267,13 @@ function checkIfHasImports(fileName, node) {
   if (fileName !== "main" && node.type === "Atrule" && node.name === "import") {
     return `  ${colors.underline(`on line ${node.loc.start.line}:`)}
   There is an import rule.
-  All imports are disallowed except for main.css`;
+  Imports are only allowed in main.css.
+  Having all imports in one file guarantees 
+  that there is only one place in the project
+  to see which CSS files are loaded. 
+  It also improves the site’s performance, 
+  since the browser only needs to load one file 
+  to know which files it needs to load afterwards.`;
   }
   return "no error";
 }

--- a/example-css-files/not-main-but-has-imports.css
+++ b/example-css-files/not-main-but-has-imports.css
@@ -1,0 +1,2 @@
+@import "./example.css";
+@import "./example2.css";


### PR DESCRIPTION
About the issue https://github.com/diesdasdigital/csslint/issues/12
- disallow imports if the file name is not `main.css`

This does not check anything if the file name is `main.css`.
