### PR TITLE
Update license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ If you want to create PR, we test and develop this tool using these as a baselin
 - [`node`](https://nodejs.org/en/) (we recommend installing it via [nvm](https://github.com/creationix/nvm))
 - [`yarn`](https://yarnpkg.com)
 
+## License
+
+MIT
+
 ---
 
 Created by [diesdas.digital](https://diesdas.digital)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In any software system relying on context creates complexity. If one needs to kn
 
 CSS in JS tools solve that problem by using inline styles and/or generating class names automatically during a build step. This way developers cannot unintentionally override other components classes, because they don’t even know what the class name will be.
 
-The downsides if CSS in JS solutions are:
+The downsides of CSS in JS solutions are:
 
 - one needs a build step to generate CSS
 - some tools require writing CSS in a non-standard way (as objects for example)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engineStrict": true,
   "repository": "https://github.com/diesdasdigital/csslint",
   "author": "diesdas.digital",
-  "license": "none",
+  "license": "MIT",
   "scripts": {
     "pre-push": "yarn -s lint",
     "start": "node ./bin/index.js",


### PR DESCRIPTION
## Proposed solution
<!-- What and Why? -->
It should be easy to see the license of a product on first glance, so in addition to the license file there should be information in `README.md` and `package.json`.

What the npm webiste shows at the moment:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/18517541/67012182-37796d00-f0f1-11e9-8f80-df139e6261fe.png">
